### PR TITLE
Add GTO chart JSON

### DIFF
--- a/gto_chart.json
+++ b/gto_chart.json
@@ -1,0 +1,22 @@
+{
+  "situations": [
+    {
+      "pot": 1500,
+      "pot_tolerance": 200,
+      "effective_stack": 12000,
+      "suggestion": "Call"
+    },
+    {
+      "pot": 3000,
+      "pot_tolerance": 200,
+      "effective_stack": 10000,
+      "suggestion": "Fold"
+    },
+    {
+      "pot": 5000,
+      "pot_tolerance": 300,
+      "effective_stack": 8000,
+      "suggestion": "Raise"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- include a JSON chart for GTO advice

## Testing
- `python -m py_compile assistant_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6850eaad3dd8832ca3898a78baf193d6