### PR TITLE
Add environment configuration template and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Server Settings
+POKER_ASSISTANT_API_KEY=make-this-value-secure
+POKER_ASSISTANT_ALLOWED_IPS=127.0.0.1,69.110.58.72
+
+# Assistant IDs
+POKER_ASSISTANT_ID_1=asst_id_for_assistant1
+POKER_ASSISTANT_ID_2=asst_id_for_assistant2
+POKER_ASSISTANT_ID_3=asst_id_for_assistant3
+POKER_ASSISTANT_ID_4=asst_id_for_assistant4
+POKER_ASSISTANT_ID_5=asst_id_for_assistant5
+POKER_ASSISTANT_ID_6=asst_id_for_assistant6
+POKER_ASSISTANT_ID_7=asst_id_for_assistant7
+POKER_ASSISTANT_ID_8=asst_id_for_assistant8
+POKER_ASSISTANT_ID_9=asst_id_for_assistant9
+POKER_ASSISTANT_ID_10=asst_id_for_assistant10
+
+# OpenAI API Key
+OPENAI_API_KEY=your-openai-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore environment files
+.env
+__pycache__/

--- a/LLM_PROMPTS.md
+++ b/LLM_PROMPTS.md
@@ -26,3 +26,5 @@ The following prompts can be provided to an advanced language model to identify 
 8. **Efficient Lookups**
    - "Propose data structures or caching strategies to quickly retrieve advice from large GTO charts. The solution should minimize latency when matching game state fields such as pot size, position, and situation type."
 
+9. **Environment Key Management**
+   - "Review the project's use of `.env` files and propose enhancements to secure and manage API keys effectively. Outline best practices for secret rotation and deployment."

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# asdfjo
+# Poker Assistant
+
+This project provides a Flask server and a local client for generating poker advice via OpenAI assistants.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your API keys and assistant IDs.
+3. Run the server:
+   ```bash
+   python assistant_server.py
+   ```
+4. Optionally, use `local_client.py` to interact with the server from your desktop.
+
+See `setup_guide.md` for detailed instructions.

--- a/SERVER_SETTINGS_PLAN.md
+++ b/SERVER_SETTINGS_PLAN.md
@@ -1,0 +1,11 @@
+# Server Settings Storage Plan
+
+This repository expects configuration values such as API keys and allowed IP addresses to be stored in a `.env` file. To keep sensitive data safe:
+
+1. **Use `.env.example` as a template.** Copy this file to `.env` and replace each placeholder value with your actual keys.
+2. **Keep `.env` out of version control.** The `.gitignore` file already excludes `.env` so secrets are not accidentally committed.
+3. **Restrict permissions.** Limit read access to `.env` on the server (e.g., `chmod 600 .env`).
+4. **Avoid storing secrets in client code.** Only the server should contain the real API keys. The client should reference a separate key meant for client authentication.
+5. **Rotate keys when needed.** If you suspect a key was exposed, generate a new one and update `.env` accordingly.
+
+Following these guidelines will help ensure that environment variables remain secure.


### PR DESCRIPTION
## Summary
- ignore `.env` in version control
- provide `.env.example` for environment variables
- document configuration and setup steps in `README`
- add plan for storing server settings in `SERVER_SETTINGS_PLAN.md`
- expand `LLM_PROMPTS.md` with environment key management prompt

## Testing
- `python -m py_compile assistant_server.py local_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6851ab200b08832c8a7e10bf06393dfe