### PR TITLE
Add /api/advice route

### DIFF
--- a/assistant_server.py
+++ b/assistant_server.py
@@ -115,6 +115,7 @@ def normalize_result(raw_text: str) -> str:
 # --- Main Route ---
 
 @app.route("/api/poker_decision", methods=["POST"])
+@app.route("/api/advice", methods=["POST"])
 def route_ocr_decision():
     t0 = time.time()
     game_state = request.json or {}


### PR DESCRIPTION
## Summary
- expose existing decision logic via `/api/advice`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685222245250832c83ff0172ac033b36