### PR TITLE
Add sample game state script

### DIFF
--- a/LLM_PROMPTS.md
+++ b/LLM_PROMPTS.md
@@ -28,3 +28,6 @@ The following prompts can be provided to an advanced language model to identify 
 
 9. **Environment Key Management**
    - "Review the project's use of `.env` files and propose enhancements to secure and manage API keys effectively. Outline best practices for secret rotation and deployment."
+
+10. **Client/Server Request Alignment**
+   - "Examine `local_client.py` and `assistant_server.py` to ensure they use consistent request formats. Suggest improvements so the client can easily send JSON game states, as demonstrated in `post_game_state.py`, while maintaining support for screenshot-based methods if needed. Provide clean code examples."

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This project provides a Flask server and a local client for generating poker adv
    ```bash
    python assistant_server.py
    ```
-4. Optionally, use `local_client.py` to interact with the server from your desktop.
+4. To quickly test the API with a sample game state, run `post_game_state.py`:
+   ```bash
+   python post_game_state.py
+   ```
+5. Optionally, use `local_client.py` to interact with the server from your desktop.
 
 See `setup_guide.md` for detailed instructions.

--- a/post_game_state.py
+++ b/post_game_state.py
@@ -1,0 +1,12 @@
+import json
+import requests
+
+with open("production_game_state.json") as f:
+    data = json.load(f)
+
+resp = requests.post(
+    "http://localhost:5000/api/advice",
+    json=data,
+)
+print(resp.text)
+


### PR DESCRIPTION
## Summary
- include example script `post_game_state.py` for sending a game state JSON to the API
- document how to use the script in README
- add prompt about client/server request alignment to `LLM_PROMPTS.md`

## Testing
- `python -m py_compile post_game_state.py`

------
https://chatgpt.com/codex/tasks/task_e_68522e27711c832c957e4318f4b0a1ee