### PR TITLE
Make YOLO optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a full stack poker assistant that routes on-table infor
    pip install -r requirements.txt
    ```
 2. Copy `.env.template` to `.env` and fill in your OpenAI key and assistant IDs.
-3. Run the server:
+3. Run the server (set `ENABLE_YOLO=0` to disable card detection):
    ```bash
    python assistant_server.py
    ```

--- a/assistant_server.py
+++ b/assistant_server.py
@@ -18,6 +18,9 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('poker_assistant')
 
+# Toggle YOLO card detection via environment
+ENABLE_YOLO = os.getenv("ENABLE_YOLO", "1").lower() not in {"0", "false", "no"}
+
 # Load assistant IDs from .env
 ASSISTANT_IDS = {i: os.getenv(f"ASSISTANT_{i}") for i in range(1, 11)}
 
@@ -114,7 +117,7 @@ def extract_game_state_from_image(image: Image.Image) -> dict:
     # Layout & helpers
     layout = PokerTableLayout(frame.shape[1], frame.shape[0], "6max")
     ocr_parser = OCRParser()
-    card_detector = CardDetector()
+    card_detector = CardDetector(enable_yolo=ENABLE_YOLO)
     action_parser = PlayerActionParser(layout, card_detector=card_detector, ocr_parser=ocr_parser)
 
     # OCR and card detection


### PR DESCRIPTION
## Summary
- allow CardDetector to initialize without YOLO
- toggle YOLO in assistant_server via `ENABLE_YOLO` env var
- document YOLO toggle in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853e0478edc832c8330f660455dc1c7