### PR TITLE
Fix screenshot capture environment

### DIFF
--- a/local_client.py
+++ b/local_client.py
@@ -11,6 +11,7 @@ import requests
 import mss
 from tkinter import Tk, Label, StringVar
 import pyttsx3
+import os
 
 # --- CONFIGURATION ---
 SERVER_URL = "http://24.199.98.206:5000/api/advice" 
@@ -85,6 +86,8 @@ class OverlayWindow:
 
 # --- Screenshot and Network ---
 def capture_frame():
+    if os.name == "posix" and "DISPLAY" not in os.environ:
+        os.environ["DISPLAY"] = ":0"
     with mss.mss() as sct:
         return sct.grab(CAPTURE_REGION)
 


### PR DESCRIPTION
## Summary
- import `os` in `local_client.py`
- ensure `DISPLAY` is set before using `mss` screen capture

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python3 screenshot_saver.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ccea7d390832c98d7159a7d26f027