### PR TITLE
Add virtual display support for headless screenshots

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,6 @@ pytesseract
 pyttsx3
 PyQt5
 keyboard
+# Virtual display for headless screenshot capture
+pyvirtualdisplay
 # tkinter comes with standard Python but may require system packages


### PR DESCRIPTION
## Summary
- enable automatic virtual display startup in `local_client.py`
- stop the virtual display on cleanup
- include `pyvirtualdisplay` in requirements

## Testing
- `python -m py_compile asdfjo/local_client.py`
- `python -m py_compile asdfjo/screenshot_saver.py`
- `python asdfjo/screenshot_saver.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685ccf9e6da4832caeba5c4249945c83