### PR TITLE
Adjust placeholder text for screenshot overlay

### DIFF
--- a/screenshot_capture_client.py
+++ b/screenshot_capture_client.py
@@ -74,7 +74,7 @@ class OverlayWindow:
             pady=10,
         )
         self.label.pack()
-        self.var.set("Waiting for advice...")
+        self.var.set("Connecting to server...")
         self.last_update = 0
 
     def set_text(self, txt: str):
@@ -115,7 +115,7 @@ def send_frame(img_bytes: bytes):
 
 # --- Main Loop ---
 def main_loop(overlay: OverlayWindow):
-    last_suggestion = "Waiting for advice..."
+    last_suggestion = "Connecting to server..."
     suggestion_lock = threading.Lock()
 
     def network_worker():


### PR DESCRIPTION
## Summary
- update the default overlay text in `screenshot_capture_client.py` to clarify that the client is connecting to the server

## Testing
- `python -m py_compile screenshot_capture_client.py`


------
https://chatgpt.com/codex/tasks/task_e_685cd859df80832cae2cc879c61527ac