### PR TITLE
Allow capture client URL via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ This repository contains a full stack poker assistant that routes on-table infor
 - `python local_client.py` – capture the table region and show overlay advice.
 - `python screenshot_server.py` – minimal server that stores uploaded screenshots.
 - `python screenshot_saver.py` – continuously capture screenshots and upload them to the screenshot server.
-- `python screenshot_capture_server.py` – serve on-demand screenshots to remote clients.
+- `python screenshot_capture_server.py` – serve on-demand screenshots to remote clients. Set `CAPTURE_SERVER_PORT` if a different port is required.
 - `python screenshot_capture_client.py` – fetch screenshots from the capture server and display advice.
+  The client loads environment variables (e.g., from a `.env` file); set `CAPTURE_SERVER_URL` to the capture server's host and port.
 - `python post_game_state.py` – send a sample JSON game state to the server.
 - `python realtime_pipeline.py` – run the demo multithreaded OCR pipeline.
 - `python gto_proxy.py --train solver_data.json --out gto_proxy_model.pkl` – train the GTO decision tree model.


### PR DESCRIPTION
## Summary
- allow `CAPTURE_SERVER_URL` to be overridden with an env variable
- document how to configure `screenshot_capture_server.py` and the capture client via environment variables
- handle connection errors in the capture client and load `.env`

## Testing
- `python -m py_compile screenshot_capture_client.py screenshot_capture_server.py local_client.py`


------
https://chatgpt.com/codex/tasks/task_e_685cdd94455c832c9839b7243e5c71b5