### PR TITLE
Enable .env loading for screenshot server

### DIFF
--- a/screenshot_capture_server.py
+++ b/screenshot_capture_server.py
@@ -6,10 +6,14 @@ import logging
 import io
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from flask import Flask, send_file, jsonify
 import mss
 
 from local_client import capture_frame
+
+load_dotenv()
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Summary
- load environment variables in `screenshot_capture_server`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce07bce44832c9f3eff9c9de270f6