### PR TITLE
Fix screenshot capture URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository contains a full stack poker assistant that routes on-table infor
 - `python screenshot_saver.py` – continuously capture screenshots and upload them to the screenshot server.
 - `python screenshot_capture_server.py` – serve on-demand screenshots to remote clients. Set `CAPTURE_SERVER_PORT` if a different port is required.
 - `python screenshot_capture_client.py` – fetch screenshots from the capture server and display advice.
-  The client loads environment variables (e.g., from a `.env` file); set `CAPTURE_SERVER_URL` to the capture server's host and port.
+  The client loads environment variables (e.g., from a `.env` file); set `CAPTURE_SERVER_URL` to the capture server's full URL (e.g., `http://<host>:5002/api/capture`).
 - `python post_game_state.py` – send a sample JSON game state to the server.
 - `python realtime_pipeline.py` – run the demo multithreaded OCR pipeline.
 - `python gto_proxy.py --train solver_data.json --out gto_proxy_model.pkl` – train the GTO decision tree model.

--- a/screenshot_capture_client.py
+++ b/screenshot_capture_client.py
@@ -7,17 +7,28 @@ import time
 import threading
 import queue
 import requests
+from urllib.parse import urlparse
 from tkinter import Tk, Label, StringVar
 import pyttsx3
 from dotenv import load_dotenv
+
+
+def _normalize_capture_url(url: str) -> str:
+    """Ensure the capture URL includes the /api/capture path."""
+    if not url:
+        return "http://localhost:5002/api/capture"
+    parsed = urlparse(url)
+    if parsed.path in ("", "/"):
+        url = url.rstrip("/") + "/api/capture"
+    return url.rstrip("/")
 
 load_dotenv()
 
 
 # --- CONFIGURATION ---
 SERVER_URL = "http://24.199.98.206:5000/api/advice"
-CAPTURE_SERVER_URL = os.environ.get(
-    "CAPTURE_SERVER_URL", "http://localhost:5002/api/capture"
+CAPTURE_SERVER_URL = _normalize_capture_url(
+    os.environ.get("CAPTURE_SERVER_URL", "http://localhost:5002/api/capture")
 )
 API_KEY = "your-secure-api-key"
 TARGET_FPS = 32


### PR DESCRIPTION
## Summary
- fix capture client to gracefully handle CAPTURE_SERVER_URL without `/api/capture`
- clarify README instructions on CAPTURE_SERVER_URL

## Testing
- `python -m py_compile screenshot_capture_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685ce3021748832c85fd189f6344e0ea